### PR TITLE
Fix nullability analyzer warnings

### DIFF
--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.h
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.h
@@ -17,13 +17,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The view from which to start an image zooming transition. This view may be hidden or shown in the transition, but will never be removed or changed in its view hierarchy.
+ *
+ *  Setting the view to `nil` will disable the zoom animation.
  */
-@property (nonatomic) UIView *startingView;
+@property (nonatomic, nullable) UIView *startingView;
 
 /**
  *  The view from which to end an image zooming transition. This view may be hidden or shown in the transition, but will never be removed or changed in its view hierarchy.
+ *
+ *  Setting the view to `nil` will disable the zoom animation.
  */
-@property (nonatomic) UIView *endingView;
+@property (nonatomic, nullable) UIView *endingView;
 
 /**
  *  The view that is used for animating the starting view. If no view is set, the starting view is screenshotted and the relevant properties are copied to the new view.

--- a/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
+++ b/NYTPhotoViewer/NYTPhotoTransitionAnimator.m
@@ -120,7 +120,13 @@ static const CGFloat NYTPhotoTransitionAnimatorSpringDamping = 0.9;
     if (!endingViewForAnimation) {
         endingViewForAnimation = [[self class] newAnimationViewFromView:self.endingView];
     }
-    
+
+    if (!startingViewForAnimation || !endingViewForAnimation) {
+        NSAssert(startingViewForAnimation && endingViewForAnimation, @"When starting or ending views are nil, zooming should not be performed.");
+        [self completeTransitionWithTransitionContext:transitionContext];
+        return;
+    }
+
     CGAffineTransform finalEndingViewTransform = self.endingView.transform;
 
     CGFloat endingViewInitialTransform = CGRectGetHeight(startingViewForAnimation.frame) / CGRectGetHeight(endingViewForAnimation.frame);

--- a/NYTPhotoViewer/NYTPhotoTransitionController.h
+++ b/NYTPhotoViewer/NYTPhotoTransitionController.h
@@ -21,13 +21,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The view from which to start an image zooming transition. This view may be hidden or shown in the transition, but will never be removed or changed in its view hierarchy.
+ *
+ *  Setting the view to `nil` will disable the zoom animation.
  */
-@property (nonatomic) UIView *startingView;
+@property (nonatomic, nullable) UIView *startingView;
 
 /**
  *  The view from which to end an image zooming transition. This view may be hidden or shown in the transition, but will never be removed or changed in its view hierarchy.
+ *
+ *  Setting the view to `nil` will disable the zoom animation.
  */
-@property (nonatomic) UIView *endingView;
+@property (nonatomic, nullable) UIView *endingView;
 
 /**
  *  Forces the dismiss to animate, instead of the default behavior of being interactive.

--- a/NYTPhotoViewer/NYTScalingImageView.h
+++ b/NYTPhotoViewer/NYTScalingImageView.h
@@ -28,12 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Initializes a scaling image view with a `UIImage`. This object is a `UIScrollView` that contains a `UIImageView`. This allows for zooming and panning around the image.
  *
- *  @param image A `UIImage` for zooming and panning.
+ *  @param image A `UIImage` for zooming and panning. May be `nil` and updated later – the view will be created regardless.
  *  @param frame The frame of the view.
  *
  *  @return A fully initialized object.
  */
-- (instancetype)initWithImage:(UIImage *)image frame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithImage:(nullable UIImage *)image frame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Initializes a scaling image view with `NSData` representing an animated image. This object is a `UIScrollView` that contains a `UIImageView`. This allows for zooming and panning around the image.


### PR DESCRIPTION
The nullability annotations were too strict, all methods and properties should handle nil just fine. I have added extra checks and documentation.
